### PR TITLE
remove unneeded fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,6 @@ Date: 2017-07-26
 Encoding: UTF-8
 Authors@R: c(person("Carlos J.", "Gil Bellosta", email="cgb@datanalytics.com", role=c('cre', 'aut')),
               person("Luz", "Frías", email = "luzfrias@gmail.com", role = "aut")) 
-Author: Carlos J. Gil Bellosta, Luz Frías
-Maintainer: Carlos J. Gil Bellosta <cgb@datanalytics.com>
 Description: Access to Cartociudad cartography API, which provides mapping and other related services for Spain.
 Imports: httr, jsonlite, xml2, plyr, geosphere
 Depends: R (>= 3.0.0)


### PR DESCRIPTION
`Author` and `Maintainer` are automatically derived from `Authors@R`.